### PR TITLE
bump version of rust-numpy

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = "1.0"
 libc = "0.2"
 env_logger = "0.11"
 pyo3 = { version = "0.22" }
-numpy = "0.21"
+numpy = "0.22"
 ndarray = "0.15"
 itertools = "0.12"
 


### PR DESCRIPTION
* Bump rust-numpy version to 0.22 so pyo3 can be upgraded to the latest version (to fix Python 3.13 compatability).